### PR TITLE
Full service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ components:
 - msm-sc: a container sidecar service for each service relying on msm
   - msm-jsc: the current (Java) implementation for the sidecar
 - msm-sdw: a listener for services arrivals who writes to etcd
+- msm-sdf: a service for finding other services
 
 Head for the component subdir for more info about them (inside their READMEs).
 
@@ -43,6 +44,7 @@ Default port numbers for msm services are settled as follows
 
 - msm-sc: 9001
 - msm-sdw: 9002
+- msm-sdf: 9003
 
 ### Developers Guidelines
 

--- a/msm-jsc/Dockerfile
+++ b/msm-jsc/Dockerfile
@@ -3,5 +3,6 @@ FROM anapsix/alpine-java:8
 COPY build/libs/msm-jsc-0.1.0.jar .
 
 ENV KAFKA_ADDR kafka:9092
+ENV SDF_ADDR msm-sdf:8080
 
 CMD java -jar msm-jsc-0.1.0.jar

--- a/msm-jsc/README.md
+++ b/msm-jsc/README.md
@@ -9,9 +9,10 @@ This is a Java implementation for msm sidecar.
 ### Depends on
 
 - Kafka
+- msm-sdf
 
-Check out msm top level README for guidance on providing components dependencies
-through Docker.
+Check out msm top level (or others msm components) README for guidance on
+providing components dependencies through Docker.
 
 ### Build
 
@@ -46,3 +47,9 @@ Set a `KAFKA_ADDR` envar. For instance (set `custom` host on port `1234`):
     $ KAFKA_ADDR=custom:1234 gradle bootRun 
 
 Default address is localhost:9092.
+
+### Config msm-sdf address
+
+As with Kafka address, just set the `SDF_ADDR` envar:
+
+    $ SDF_ADDR=custom:6547 gradle bootRun

--- a/msm-jsc/build.gradle
+++ b/msm-jsc/build.gradle
@@ -24,5 +24,7 @@ targetCompatibility = 1.8
 dependencies {
   compile group: 'org.apache.kafka', name: 'kafka-clients', version: '0.11.0.0'
   compile 'org.springframework.boot:spring-boot-starter-web'
+  compile("org.springframework:spring-web")
+  compile("com.fasterxml.jackson.core:jackson-databind")
   testCompile 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/msm-jsc/src/main/java/msm/sc/MainController.java
+++ b/msm-jsc/src/main/java/msm/sc/MainController.java
@@ -10,7 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class MainController {
 
   @RequestMapping("/register")
-  public void register(@RequestParam(value="name") String name) {
-    ProducerSing.i().send(new ProducerRecord<String,String>("register", name));
+  public void register(@RequestParam(value="name") String name,
+                       @RequestParam(value="host") String host,
+                       @RequestParam(value="port") String port) {
+    ProducerRecord<String, String> record;
+    final String TOPIC = "register";
+    String address = String.format("%s:%s", host, port);
+    record = new ProducerRecord<String, String>(TOPIC, name, address);
+
+    ProducerSing.i().send(record);
   }
 }

--- a/msm-jsc/src/main/java/msm/sc/MainController.java
+++ b/msm-jsc/src/main/java/msm/sc/MainController.java
@@ -2,6 +2,9 @@ package msm.sc;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,5 +22,35 @@ public class MainController {
     record = new ProducerRecord<String, String>(TOPIC, name, address);
 
     ProducerSing.i().send(record);
+  }
+
+  @RequestMapping("/lookup")
+  public Service lookup(@RequestParam(value="name") String name) {
+    RestTemplate restTemplate = new RestTemplate();
+    Service service = null;
+
+    try {
+      service = restTemplate.getForObject(lookupUri(name), Service.class);
+    } catch(HttpClientErrorException e) {
+      if(e.getStatusCode() == HttpStatus.NOT_FOUND)
+        throw new ServiceNotFoundException();
+
+      throw e;
+    }
+
+    return service;
+  }
+
+  private String lookupUri(String serviceName) {
+    return String.format("http://%s/lookup?name=%s", sdfAddr(), serviceName);
+  }
+
+  private String sdfAddr() {
+    String addr = System.getenv("SDF_ADDR");
+
+    if(addr == null)
+      addr = "localhost:9003";
+
+    return addr;
   }
 }

--- a/msm-jsc/src/main/java/msm/sc/Service.java
+++ b/msm-jsc/src/main/java/msm/sc/Service.java
@@ -1,0 +1,28 @@
+package msm.sc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Service {
+  private String name;
+  private String address;
+
+  public Service() {
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getAddress() {
+    return this.address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+}

--- a/msm-jsc/src/main/java/msm/sc/ServiceNotFoundException.java
+++ b/msm-jsc/src/main/java/msm/sc/ServiceNotFoundException.java
@@ -1,0 +1,12 @@
+package msm.sc;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class ServiceNotFoundException extends RuntimeException {
+
+  public ServiceNotFoundException() {
+    super("There is currently no service available for the given name.");
+  }
+}

--- a/msm-sdf/Dockerfile
+++ b/msm-sdf/Dockerfile
@@ -1,0 +1,7 @@
+FROM anapsix/alpine-java:8
+
+COPY build/libs/msm-sdf-0.1.0.jar .
+
+ENV ETCD_ADDR etcd:2379
+
+CMD java -jar msm-sdf-0.1.0.jar

--- a/msm-sdf/README.md
+++ b/msm-sdf/README.md
@@ -1,0 +1,47 @@
+msm **S**ervice **D**iscovery **F**inder: a service for fetching services
+addresses from etcd services registry.
+
+### Built with
+
+- Java 8
+- Spring Framework
+- Gradle
+
+### Depends on
+
+- etcd
+
+Check out msm top level README for guidance on providing components dependencies
+through Docker.
+
+### Build
+
+    $ gradle build
+
+### Run
+
+    $ gradle bootRun
+
+Or as a jar:
+
+    $ java -jar build/libs/msm-sdf-0.1.0.jar
+
+### Docker
+
+Build image (make sure you've already built the project for generating the jar)
+
+    $ docker build -t embs/msm-sdf .
+
+Create msm network if you haven't already:
+
+    $ docker network create msm
+
+Run
+
+    $ docker run --name msm-sdf --network msm -d -p 9003:8080 embs/msm-sdf
+
+### Config etcd node address
+
+Set a `ETCD_ADDR` envar. For instance (set `custom` host on port `1234`):
+
+    $ ETCD_ADDR=custom:1234 gradle bootRun

--- a/msm-sdf/build.gradle
+++ b/msm-sdf/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath "org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE"
+  }
+}
+
+apply plugin: 'org.springframework.boot'
+
+jar {
+  baseName = 'msm-sdf'
+  version  = '0.1.0'
+}
+
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+  compile 'org.springframework.boot:spring-boot-starter-web'
+  compile group: 'com.coreos', name: 'jetcd', version: '0.1.0-SNAPSHOT'
+  testCompile 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/msm-sdf/src/main/java/msm/sdf/Application.java
+++ b/msm-sdf/src/main/java/msm/sdf/Application.java
@@ -1,0 +1,12 @@
+package msm.sdf;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+}

--- a/msm-sdf/src/main/java/msm/sdf/MainController.java
+++ b/msm-sdf/src/main/java/msm/sdf/MainController.java
@@ -1,0 +1,50 @@
+package msm.sdf;
+
+import com.coreos.jetcd.Client;
+import com.coreos.jetcd.ClientBuilder;
+import com.coreos.jetcd.KV;
+import com.coreos.jetcd.kv.GetResponse;
+import com.coreos.jetcd.kv.PutResponse;
+import com.coreos.jetcd.data.ByteSequence;
+import com.coreos.jetcd.data.KeyValue;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MainController {
+
+  @RequestMapping("/lookup")
+  public Service register(@RequestParam(value="name") String name) throws Exception {
+    Client client = ClientBuilder.newBuilder().setEndpoints(etcdAddr()).build();
+    KV kvClient = client.getKVClient();
+
+    ByteSequence key = ByteSequence.fromString(name);
+
+    CompletableFuture<GetResponse> getFuture = kvClient.get(key);
+    GetResponse response = getFuture.get();
+    List<KeyValue> kvs = response.getKvs();
+
+    if(kvs.isEmpty())
+      throw new ServiceNotFoundException();
+
+    KeyValue kv = kvs.get(0);
+    String serviceName = kv.getKey().toStringUtf8();
+    String serviceAddr = kv.getValue().toStringUtf8();
+
+    return new Service(serviceName, serviceAddr);
+  }
+
+  private String etcdAddr() {
+    String envar = System.getenv("ETCD_ADDR");
+
+    if(envar != null)
+      return envar;
+
+    return "http://0.0.0.0:2379";
+  }
+}

--- a/msm-sdf/src/main/java/msm/sdf/Service.java
+++ b/msm-sdf/src/main/java/msm/sdf/Service.java
@@ -1,0 +1,19 @@
+package msm.sdf;
+
+public class Service {
+  private final String name;
+  private final String address;
+
+  public Service(String name, String address) {
+    this.name = name;
+    this.address = address;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getAddress() {
+    return this.address;
+  }
+}

--- a/msm-sdf/src/main/java/msm/sdf/ServiceNotFoundException.java
+++ b/msm-sdf/src/main/java/msm/sdf/ServiceNotFoundException.java
@@ -1,0 +1,12 @@
+package msm.sdf;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class ServiceNotFoundException extends RuntimeException {
+
+  public ServiceNotFoundException() {
+    super("There is currently no service available for the given name.");
+  }
+}

--- a/msm-sdw/src/main/java/msm/sdw/Main.java
+++ b/msm-sdw/src/main/java/msm/sdw/Main.java
@@ -15,7 +15,7 @@ public class Main {
         System.out.printf("offset = %d, key = %s, value = %s%n",
                           record.offset(), record.key(), record.value());
 
-        writer.write("new_service", record.value());
+        writer.write(record.key(), record.value());
       }
     }
   }


### PR DESCRIPTION
Allow registering and looking up for services. Example:

```
embs@crow ~/Code/msm/msm-jsc $ docker ps
CONTAINER ID        IMAGE                        COMMAND                  CREATED             STATUS              PORTS                                            NAMES
3e097c55953a        embs/msm-jsc                 "/bin/sh -c 'java ..."   14 minutes ago      Up 14 minutes       0.0.0.0:9001->8080/tcp                           msm-jsc
b5aa0eb391a0        embs/msm-sdf                 "/bin/sh -c 'java ..."   About an hour ago   Up About an hour    0.0.0.0:9003->8080/tcp                           msm-sdf
bf3d93b018b5        embs/msm-sdw                 "/bin/sh -c 'java ..."   2 hours ago         Up 2 hours          0.0.0.0:9002->8080/tcp                           msm-sdw
a807ff4a6083        quay.io/coreos/etcd:v3.2.1   "/usr/local/bin/et..."   6 hours ago         Up 6 hours          0.0.0.0:2379-2380->2379-2380/tcp                 etcd
d6e65c98dcdb        spotify/kafka                "supervisord -n"         8 hours ago         Up 8 hours          0.0.0.0:2181->2181/tcp, 0.0.0.0:9092->9092/tcp   kafka
embs@crow ~/Code/msm/msm-jsc $ etcd-list
mservice
localhost:4145
new_service
bank:5478
embs@crow ~/Code/msm/msm-jsc $ curl "localhost:9001/register?name=agreatservice&host=greatcontainer&port=7894"
embs@crow ~/Code/msm/msm-jsc $ etcd-list
agreatservice
greatcontainer:7894
mservice
localhost:4145
new_service
bank:5478
embs@crow ~/Code/msm/msm-jsc $ curl localhost:9001/lookup?name=agreatservice
{"name":"agreatservice","address":"greatcontainer:7894"}
```